### PR TITLE
Create test_bioimageio_resources.yaml

### DIFF
--- a/.github/workflows/test_bioimageio_resources.yaml
+++ b/.github/workflows/test_bioimageio_resources.yaml
@@ -1,0 +1,59 @@
+name: test BioImage.IO resources  # for compatibility with BioEngine model runner
+
+concurrency: test-resources
+
+on:
+  workflow_dispatch:
+    inputs:
+      pending_matrix:
+        description: 'json encoded gh matrix of pending validations for new or updated resources (default: test on all resources)'
+        required: true
+        default: '{"include": [{"resource_id": "**", "version_id": "**"}]}'
+        type: string
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix: ${{ fromJson(inputs.pending_matrix) }}
+
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/checkout@v2  # checkout gh-pages to make sure we have access to latest deployment (raw.githubusercontent.com might be behind)
+      with:
+        repository: bioimage-io/collection-bioimage-io
+        ref: gh-pages
+        path: bioimageio-gh-pages
+
+    - name: test with docker container
+      run: |
+        mkdir -p dist/${{ matrix.resource_id }}/${{ matrix.version_id }}
+        echo 'TODO' > dist/${{ matrix.resource_id }}/${{ matrix.version_id }}/test_summary.yaml
+        echo 'TODO: generate test_summary using docker container'
+    - name: prepare artifact upload
+      run: echo ::set-output name=name::$(${{ matrix.resource_id }}${{ matrix.version_id }} | sed 's#/##g')  # remove '/' from artifact name
+    - name: Upload test summaries
+      uses: actions/upload-artifact@v3
+      with:
+        name: ${{ prep_artifact.outputs.name }}
+        path: dist
+        retention-days: 1
+
+  deploy:
+    needs: run
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/download-artifact@v3
+      with:
+        path: artifacts
+    - name: merge test summaries  # (they differ by path or postfix)
+      run: |
+        mkdir dist
+        cp -r artifacts/*/* dist
+    - name: Deploy test summaries to gh-pages 🚀
+      uses: JamesIves/github-pages-deploy-action@v4.2.3
+      with:
+        clean: false
+        branch: gh-pages
+        folder: dist


### PR DESCRIPTION
WIP

draft:
 - workflow to be called by BioImage.IO Bot to test BioImage.IO models for compatibility to the (current?) bioengine model runner

missing:
 - [ ] generating "test_summary*.yaml" from calling the BioEngine docker container for a specific model.
 
this workflow could alternatively be added to https://github.com/bioimage-io/bioimage-io-resources

cc @oeway @constantinpape 