### PR TITLE
Fix gpu tensor error with cupy

### DIFF
--- a/src/bioengine-model-runner/1/model.py
+++ b/src/bioengine-model-runner/1/model.py
@@ -43,18 +43,6 @@ logging.basicConfig(
 logger = logging.getLogger("bioengine-runner")
 logger.setLevel(logging.INFO)
 
-# model_snapshots_directory = os.environ.get("MODEL_SNAPSHOTS_DIRECTORY")
-# if model_snapshots_directory:
-#     assert os.path.exists(
-#         model_snapshots_directory
-#     ), f'Model snapshots directory "{model_snapshots_directory}" (from env virable MODEL_SNAPSHOTS_DIRECTORY) does not exist'
-#     MODEL_DIR = os.path.join(model_snapshots_directory, "bioimageio-models")
-# else:
-#     MODEL_DIR = os.path.join(os.path.dirname(__file__), "../../../bioimageio-models")
-
-# os.makedirs(MODEL_DIR, exist_ok=True)
-# os.environ["BIOIMAGEIO_CACHE_PATH"] = os.environ.get("BIOIMAGEIO_CACHE_PATH", MODEL_DIR)
-# os.environ["BIOIMAGEIO_USE_CACHE"] = "no"
 
 print(
     f"BioEngine Model Runner (bioimageio.spec: {bioimageio.spec.__version__}, bioimageio.core: {bioimageio.core.__version__})"

--- a/src/bioengine-model-runner/README.md
+++ b/src/bioengine-model-runner/README.md
@@ -5,6 +5,7 @@
 export PYTHONNOUSERSITE=True
 conda create -n bioengine-model-runner python=3.8 # we use 3.8 so we don't need to provide the stub
 pip install -U https://github.com/bioimage-io/core-bioimage-io-python/archive/e335077dfaa282fb4982b85ef17cb46ddd939837.zip
+conda install -c conda-forge cupy # This is needed for now, for converting GPU tensor to numpy, see https://github.com/triton-inference-server/server/issues/3992#issuecomment-1055464670
 pip install -U bioimageio.spec xarray imjoy-rpc requests msgpack tritonclient[http]
 conda install conda-pack
 conda-pack

--- a/src/bioengine-model-runner/config.pbtxt
+++ b/src/bioengine-model-runner/config.pbtxt
@@ -16,7 +16,7 @@ output [
   }
 ]
 
-instance_group [{ count: 1, kind: KIND_CPU }]
+instance_group [{ count: 1, kind: KIND_GPU }]
 
 parameters: {
   key: "EXECUTION_ENV_PATH",


### PR DESCRIPTION
We use cupy for now to convert triton tensor to numpy, it's possible that we can get it without cupy if triton eventually provide utility tools for it.